### PR TITLE
Clean up ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   build:
+    # We want to run on external PRs, but not on our own internal PRs as
+    # they'll be run by the push to the branch.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false # Let the workflow continue as much as possible
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,55 +3,40 @@ name: ci
 on:
   push:
   pull_request:
-
-env:
-  ROSWELL_VERSION_TAG: v21.06.14.110
+  schedule:
+    - cron: "0 0 * * SUN"
 
 jobs:
-
   build:
     strategy:
       fail-fast: false # Let the workflow continue as much as possible
       matrix:
         include:
           - os: windows-latest
-            shell: 'msys2 {0}'
-            lisp: sbcl-bin/2.1.8
+            shell: bash
+            lisp: sbcl-bin
             destination: cg.exe
-
           - os: ubuntu-latest
             shell: bash
-            lisp: sbcl-bin/2.1.8
+            lisp: sbcl-bin
             destination: cg-linux
-
           - os: macos-latest
             shell: bash
-            lisp: sbcl-bin/2.1.8
+            lisp: sbcl-bin
             destination: cg-osx
-
     defaults:
       run:
         shell: ${{ matrix.shell }}
-
     env:
       LISP: ${{ matrix.lisp }}
-
     name: build with ${{ matrix.lisp }} on ${{ matrix.os }}
-
     runs-on: ${{ matrix.os }}
-
     steps:
-
-      - uses: msys2/setup-msys2@v2
-        if: matrix.os == 'windows-latest'
+      - uses: iamFIREcracker/setup-lisp@windows-work
         with:
-          install: make unzip
-
-      - name: Set up roswell to run on Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "ROSWELL_INSTALL_DIR=/usr/local" >> $GITHUB_ENV
-
+          roswell-version: v21.06.14.110
+      - name: Update ql dist if we have one cached
+        run: ros -e '(ql:update-all-dists :prompt nil)'
       - name: Set up caching for roswell files
         id: cache-dot-roswell
         uses: actions/cache@v1
@@ -61,52 +46,48 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-dot-roswell-${{ matrix.lisp }}-
             ${{ runner.os }}-dot-roswell-
-
-      - name: Install roswell
-        run: curl -L https://raw.githubusercontent.com/roswell/roswell/${{ env.ROSWELL_VERSION_TAG }}/scripts/install-for-ci.sh | sh -x
-
-      - name: Update ql dist if we have one cached
-        run: ros -e "(ql:update-all-dists :prompt nil)"
-
       - uses: actions/checkout@v2
-
-      - name: Build the executable
+        with:
+          # By default, this action would fetch a single commit only;
+          # however, we are counting the number of commits since the "last tag"
+          # inside build.lisp, and in order for that to work we have to figure
+          # out a way to fetch all the ancestors of the current commit until we
+          # land on the target tag...or we fetch all the history.
+          #
+          # Fetching the complete history will do just fine.
+          fetch-depth: 0
+      - name: Build the binary
         run: |
           make binary-ros
-          bin/cg --version
           mv bin/cg bin/${{ matrix.destination }}
+      - name: Test loading of custom .cgrc
+        run: |
+          bin/${{ matrix.destination }} --version
 
-      - name: Upload the executable
+          cat <<EOF > ~/.cgrc
+          (cg:define-guesser echo
+              ("(.+)" (cmd))
+            (format NIL "~a" cmd))
+          EOF
+          bin/${{ matrix.destination }} --debug | grep ECHO
+      - name: Upload the binary
         uses: actions/upload-artifact@v2
         with:
-          name: executables
+          name: binaries
           path: bin/${{ matrix.destination }}
-
-
   release:
     if: startsWith(github.ref, 'refs/tags/')
-
     needs: [build]
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
-
       - uses: actions/download-artifact@v2
         with:
-          name: executables
+          name: binaries
           path: bin/
-
       - name: Extract release notes
         id: extract-release-notes
         uses: ffurrer2/extract-release-notes@v1
-
-      - name: Debug
-        run: |
-          ls -al bin/
-          echo "${{  steps.extract-release-notes.outputs.release_notes }}"
-
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean binary-sbcl binary install
+.PHONY: clean binary binary-ros binary-sbcl install lisp-info lisp-info-ros
 
 PREFIX?=/usr/local
 lisps := $(shell find .  -type f \( -iname \*.asd -o -iname \*.lisp \))
@@ -13,15 +13,21 @@ clean:
 bin:
 	mkdir -p bin
 
-binary-sbcl: bin $(lisps)
+lisp-info:
+	sbcl --noinform --quit \
+		--load "build/info.lisp"
+
+binary-sbcl: lisp-info bin $(lisps)
 	sbcl --noinform \
-		--load "build/info.lisp" \
 		--load "build/setup.lisp" \
 		--load "build/build.lisp"
 
-binary-ros: bin $(lisps)
+lisp-info-ros:
+	ros run -- --noinform --quit \
+		--load "build/info.lisp"
+
+binary-ros: lisp-info-ros bin $(lisps)
 	ros run -- --noinform \
-		--load "build/info.lisp" \
 		--load "build/setup.lisp" \
 		--load "build/build.lisp"
 


### PR DESCRIPTION
- Use the 40ants/setup-lisp action to setup Common Lisp -- I am actually
  linking a personal fork of the above action, waiting for the
  40ants/setup-lisp/pull/2 to be merged
- s/executable/binary for redability's sake
- Remove all the whitespace -- again, for readability's sake
- Reset Windows's default shell to: bash
- Stop adding "trivial-features" to built binaries
- Fetch the full repo history so we can properly populate *VERSION*
- Add task to test parsing a dummy RC file
- Force a build every Saturday night, and stop pinning `sbcl`

  The only reason why I pinned `sbcl` was so that I could have
  repeatable builds; however, if a build is going to be triggered
  anyway, every week, then we might as well try the latest version
  available.

- Pin the specific version of Roswell to use